### PR TITLE
fix: refine event agent instructions

### DIFF
--- a/11-mcp/code_samples/github-mcp/app.py
+++ b/11-mcp/code_samples/github-mcp/app.py
@@ -271,7 +271,7 @@ You are an expert on GitHub repositories. When answering questions, you **must**
 *   Who created the repositories
 *   The programming languages used
 *   Information found in files and README.md files within those repositories
-*   Provide links to each repository referenfced in your answers
+*   Provide links to each repository referenced in your answers
 
 **Important:** Never perform general searches for repositories. Always use the given GitHub username to find the relevant information. If a GitHub username is not provided, state that you need a username to proceed.
     """
@@ -313,10 +313,10 @@ Hackathon prize categories:
 You are an Event Recommendation Agent specializing in suggesting relevant tech events.
 
 Your task:
-1. Review the project idea recommended by the Hackathon Agent
+1. Review the project idea recommended by the Hackathon Agent.
 2. Use the search_events function to find relevant events based on the technologies mentioned.
-3. NEVER suggest and event that the where there is not a relevant technology that the user has used.
-3. ONLY recommend events that were returned by the search_events functionf
+3. Never suggest an event unless it includes a technology the user has used.
+4. Only recommend events that were returned by the search_events function.
 
 When making recommendations:
 - IMPORTANT: You must first call the search_events function with appropriate technology keywords from the project


### PR DESCRIPTION
## Summary
- fix typo in GitHub instructions
- clarify event agent guidelines and numbering

## Testing
- `python -m py_compile 11-mcp/code_samples/github-mcp/app.py`


------
https://chatgpt.com/codex/tasks/task_e_689cee89b0fc832692b9722d00b5a1a0